### PR TITLE
Fixes to ARC forbidding Objective-C objects in union

### DIFF
--- a/Slash/SLSTagParser.gen.h
+++ b/Slash/SLSTagParser.gen.h
@@ -58,8 +58,8 @@
 typedef union YYSTYPE
 
 {
-    NSString    *text;
-    NSRange     attribute_range;
+    __unsafe_unretained NSString    *text;
+    __unsafe_unretained NSRange     attribute_range;
     struct{}    noval;
 }
 /* Line 1529 of yacc.c.  */


### PR DESCRIPTION
Current version of Xcode/cocoapods won't compile with Slash, giving the error "ARC forbids Objective-C objects in unions" in SLSTagParser.gen.h
